### PR TITLE
ci: add dependabot for gha, update workflows generally, and use v1,v2,etc tags instead of branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/action-k3s-helm/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/release-updates.yaml
+++ b/.github/workflows/release-updates.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   actions-tagger:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
       # NOTE: We pin a version not to have the source code (.ts files), but the

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
           - k3s-channel: v1.20
             test-pods: restarted healthy non-ready pending
             input-namespace: ""
+            input-pod-selector: pod-number notin (2,3)
             input-important-workloads: pod/test-healthy-1 pod/test-healthy-2
           - k3s-channel: v1.20
             test-pods: ""
@@ -93,6 +94,7 @@ jobs:
         id: k8s-namespace-report
         with:
           namespace: ${{ matrix.input-namespace }}
+          pod-selector: ${{ matrix.input-pod-selector }}
           important-workloads: ${{ matrix.input-important-workloads }}
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,13 +38,13 @@ jobs:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
           - k3s-channel: v1.20
-            test-namespace: ""
             test-pods: restarted healthy non-ready pending
-            test-important-workloads: pod/test-healthy-1 pod/test-healthy-2
+            input-namespace: ""
+            input-important-workloads: pod/test-healthy-1 pod/test-healthy-2
           - k3s-channel: v1.20
-            test-namespace: kube-system
             test-pods: ""
-            test-important-workloads: ""
+            input-namespace: kube-system
+            input-important-workloads: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -92,8 +92,8 @@ jobs:
         uses: ./
         id: k8s-namespace-report
         with:
-          namespace: ${{ matrix.test-namespace }}
-          important-workloads: ${{ matrix.test-important-workloads }}
+          namespace: ${{ matrix.input-namespace }}
+          important-workloads: ${{ matrix.input-important-workloads }}
 
 
       # - name: Validate local action's set outputs/envs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@
 repos:
   # Shell script code formatting
   - repo: https://github.com/lovesegfault/beautysh
-    rev: 6.0.1
+    rev: v6.2.1
     hooks:
       - id: beautysh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,35 @@
 # Changelog
 
-## [1.0]
+## 1.1
 
-### [1.0.0]
+### 1.1.0 - 2021-09-25
+
+#### Enhancements made
+
+- Show PersistentVolumes and PersistentVolumeClaims [#11](https://github.com/jupyterhub/action-k8s-namespace-report/pull/11) ([@manics](https://github.com/manics))
+- Add pod-selector input to limit reporting [#6](https://github.com/jupyterhub/action-k8s-namespace-report/pull/6) ([@consideRatio](https://github.com/consideRatio))
+- Show info about restarted pods before pending/non-ready pods [#4](https://github.com/jupyterhub/action-k8s-namespace-report/pull/4) ([@consideRatio](https://github.com/consideRatio))
+
+#### Bugs fixed
+
+- fix: don't let namespace modify kubeconfig's current context [#5](https://github.com/jupyterhub/action-k8s-namespace-report/pull/5) ([@consideRatio](https://github.com/consideRatio))
+
+#### Continuous integration
+
+- ci: ensure actions-tagger has the permissions to update branches/tags [#8](https://github.com/jupyterhub/action-k8s-namespace-report/pull/8) ([@consideRatio](https://github.com/consideRatio))
+
+#### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/action-k8s-namespace-report/graphs/contributors?from=2021-01-11&to=2021-09-25&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Faction-k8s-namespace-report+involves%3AconsideRatio+updated%3A2021-01-11..2021-09-25&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Faction-k8s-namespace-report+involves%3Amanics+updated%3A2021-01-11..2021-09-25&type=Issues)
+
+## 1.0
+
+### 1.0.1 - 2021-01-11
+
+Critical bugfix and documentation improvements.
+
+### 1.0.0 - 2021-01-11
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 GitHub Action to report info and logs from the current namespace.
 
 ## Optional input parameters
-- `namespace`: Updates the kubeconfig's current context's namespace to this
-  namespace.
+- `namespace`: Emit a report for another namespace than the kubeconfig's current
+  context.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ GitHub Action to report info and logs from the current namespace.
 ## Optional input parameters
 - `namespace`: Emit a report for another namespace than the kubeconfig's current
   context.
+- `pod-selector`: Limit pod reporting to pods with certain labels, example:
+  `app.kubernetes.io/component notin (logger,metrics)`.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 
@@ -35,6 +37,7 @@ jobs:
         if: always()
         # with:
         #   namespace: my-namespace
+        #   pod-selector: app.kubernetes.io/component notin (logger,metrics)
         #   important-workloads: deploy/my-deployment sts/my-statefulset
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action to report info and logs from the current namespace.
 - `namespace`: Emit a report for another namespace than the kubeconfig's current
   context.
 - `pod-selector`: Limit pod reporting to pods with certain labels, example:
-  `app.kubernetes.io/component notin (logger,metrics)`.
+  `app.kubernetes.io/component notin (secret-server,boring-server)`.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 
@@ -37,7 +37,7 @@ jobs:
         if: always()
         # with:
         #   namespace: my-namespace
-        #   pod-selector: app.kubernetes.io/component notin (logger,metrics)
+        #   pod-selector: app.kubernetes.io/component notin (secret-server,boring-server)
         #   important-workloads: deploy/my-deployment sts/my-statefulset
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,22 +1,19 @@
 # Reference: https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions
 ---
 name: Kubernetes namespace report
+# Manually keep the action, input, and output descriptions in sync with the
+# readme!
 description: |
-  Emits a report of the current k8s cluster and the current namespace.
-
-branding:
-  icon: server
-  color: purple
+  GitHub Action to report info and logs from the current namespace.
 
 inputs:
-  # Manually keep the descriptions synced with the readme!
   namespace:
     default: ""
     description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
   pod-selector:
     default: ""
-    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (logger,metrics)`."
+    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (secret-server,boring-server)`. "
     required: false
   important-workloads:
     default: ""
@@ -27,6 +24,10 @@ inputs:
 #   my-output:
 #     description: "..."
 #     value: "..."
+
+branding:
+  icon: server
+  color: purple
 
 runs:
   using: "composite"

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
   # Manually keep the descriptions synced with the readme!
   namespace:
     default: ""
-    description: "Updates the kubeconfig's current context's namespace to this namespace."
+    description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
   important-workloads:
     default: ""
@@ -32,16 +32,10 @@ runs:
       run: |
         exit 0
 
-    - name: Update current namespace
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.namespace }}" ]; then
-            sudo --preserve-env kubectl config set-context --current --namespace="${{ inputs.namespace }}" > /dev/null
-        fi
-
     - name: Emit namespace report
       shell: bash
       env:
         REPORT_IMPORTANT_WORKLOADS: ${{ inputs.important-workloads }}
+        NAMESPACE: ${{ inputs.namespace }}
       run: |
         ${{ github.action_path }}/k8s-namespace-report

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     default: ""
     description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
+  pod-selector:
+    default: ""
+    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (logger,metrics)`."
+    required: false
   important-workloads:
     default: ""
     description: "Always provide logs of these workloads. Use space a separator, example: `deploy/my-deployment sts/my-statefulset`."
@@ -37,5 +41,6 @@ runs:
       env:
         REPORT_IMPORTANT_WORKLOADS: ${{ inputs.important-workloads }}
         NAMESPACE: ${{ inputs.namespace }}
+        POD_SELECTOR: ${{ inputs.pod-selector }}
       run: |
         ${{ github.action_path }}/k8s-namespace-report

--- a/ci/healthy-pod.yaml
+++ b/ci/healthy-pod.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-healthy-1
+  labels:
+    pod-number: "1"
 spec:
   containers:
     - name: busybox
@@ -18,6 +20,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-healthy-2
+  labels:
+    pod-number: "2"
 spec:
   containers:
     - name: busybox

--- a/ci/pending-pod.yaml
+++ b/ci/pending-pod.yaml
@@ -2,7 +2,23 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-pending
+  name: test-pending-1
+  labels:
+    pod-number: "1"
+spec:
+  # nodeSelector to ensure this pod never becomes scheduled
+  nodeSelector:
+    test.jupyter.org/node: no-node-has-this-label
+  containers:
+    - name: busybox
+      image: busybox
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pending-2
+  labels:
+    pod-number: "2"
 spec:
   # nodeSelector to ensure this pod never becomes scheduled
   nodeSelector:

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -35,6 +35,11 @@ export f_h3_ok="\n\033[${green};1m%s\033[0m\n"
 export f_h2_err="\n\033[${red};1m%s\n\033[${red};1m${divider}\033[0m\n"
 export f_h3_err="\n\033[${red};1m%s\033[0m\n"
 
+# We compactify the passing of --namespace, and by using --namespace= we can
+# ensure even a blank string will result in the correct behavior without
+# erroring, which is to use the current contexts namespace.
+export ns=--namespace=${NAMESPACE}
+
 printf "$f_h1_ok" "# Full namespace report"
 
 # Provide a resource overview
@@ -42,13 +47,13 @@ printf "$f_h1_ok" "# Full namespace report"
 printf "\n\n"
 printf "$f_h2_ok" "## Resource overview"
 printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset,pod"
-kubectl get deploy,sts,ds,pod
+kubectl get deploy,sts,ds,pod ${ns}
 printf "$f_h3_ok" "### \$ kubectl get secret,configmap"
-kubectl get secret,cm
+kubectl get secret,cm ${ns}
 printf "$f_h3_ok" "### \$ kubectl get service,ingress,networkpolicy"
-kubectl get svc,ing,netpol
+kubectl get svc,ing,netpol ${ns}
 printf "$f_h3_ok" "### \$ kubectl get serviceaccount,role,rolebinding"
-kubectl get sa,role,rolebinding
+kubectl get sa,role,rolebinding ${ns}
 
 
 # Check if any container of any pod has a restartCount > 0. Then, we inspect
@@ -61,7 +66,7 @@ kubectl get sa,role,rolebinding
 #       ref: https://github.com/kubernetes/kubernetes/issues/97530
 #
 PODS_RESTARTED=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(
@@ -79,9 +84,9 @@ if [ -n "$PODS_RESTARTED" ]; then
 
     for var in $PODS_RESTARTED; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
         printf "$f_h3_err" "### \$ kubectl logs --previous --all-containers --follow --ignore-errors pod/$var"
-        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var || echo  # a newline on failure for consistency
+        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var ${ns} || echo  # a newline on failure for consistency
     done
 fi
 
@@ -89,7 +94,7 @@ fi
 # Check if any pods are pending
 #
 PODS_PENDING=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(.status.phase == "Pending")
@@ -103,7 +108,7 @@ if [ -n "$PODS_PENDING" ]; then
 
     for var in $PODS_PENDING; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
     done
 fi
 
@@ -111,7 +116,7 @@ fi
 # Check if any pod has a container with a non-ready status
 #
 PODS_NON_READY=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(
@@ -129,9 +134,9 @@ if [ -n "$PODS_NON_READY" ]; then
 
     for var in $PODS_NON_READY; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
         printf "$f_h3_err" "### \$ kubectl logs --all-containers pod/$var"
-        kubectl logs --all-containers pod/$var || echo  # a newline on failure for consistency
+        kubectl logs --all-containers pod/$var ${ns} || echo  # a newline on failure for consistency
     done
 
 fi
@@ -146,6 +151,6 @@ if [ -n "$REPORT_IMPORTANT_WORKLOADS" ]; then
 
     for var in $REPORT_IMPORTANT_WORKLOADS; do
         printf "$f_h3_ok" "### \$ kubectl logs --all-containers $var"
-        kubectl logs --all-containers $var || echo  # a newline on failure for consistency
+        kubectl logs --all-containers $var ${ns} || echo  # a newline on failure for consistency
     done
 fi

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -51,6 +51,41 @@ printf "$f_h3_ok" "### \$ kubectl get serviceaccount,role,rolebinding"
 kubectl get sa,role,rolebinding
 
 
+# Check if any container of any pod has a restartCount > 0. Then, we inspect
+# their logs with --previous.
+#
+# NOTE: We also add --follow and --ignore-errors in order to ensure we get the
+#       information from all containers, and combined with --previous it will
+#       exit and not get stuck.
+#
+#       ref: https://github.com/kubernetes/kubernetes/issues/97530
+#
+PODS_RESTARTED=$(
+    kubectl get pods -o json \
+        | jq -r '
+            .items[]
+            | select(
+                any(.status.initContainerStatuses[]?; .restartCount > 0)
+                or
+                any(.status.containerStatuses[]?; .restartCount > 0)
+            )
+            | .metadata.name
+    '
+)
+if [ -n "$PODS_RESTARTED" ]; then
+    printf "\n\n"
+    printf "$f_h2_err" "## Pods with restarted containers detected!"
+    echo "$PODS_RESTARTED" | xargs --max-args=1 echo -
+
+    for var in $PODS_RESTARTED; do
+        printf "$f_h3_err" "### \$ kubectl describe pod/$var"
+        kubectl describe pod/$var
+        printf "$f_h3_err" "### \$ kubectl logs --previous --all-containers --follow --ignore-errors pod/$var"
+        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var || echo  # a newline on failure for consistency
+    done
+fi
+
+
 # Check if any pods are pending
 #
 PODS_PENDING=$(
@@ -99,41 +134,6 @@ if [ -n "$PODS_NON_READY" ]; then
         kubectl logs --all-containers pod/$var || echo  # a newline on failure for consistency
     done
 
-fi
-
-
-# Check if any container of any pod has a restartCount > 0. Then, we inspect
-# their logs with --previous.
-#
-# NOTE: We also add --follow and --ignore-errors in order to ensure we get the
-#       information from all containers, and combined with --previous it will
-#       exit and not get stuck.
-#
-#       ref: https://github.com/kubernetes/kubernetes/issues/97530
-#
-PODS_RESTARTED=$(
-    kubectl get pods -o json \
-        | jq -r '
-            .items[]
-            | select(
-                any(.status.initContainerStatuses[]?; .restartCount > 0)
-                or
-                any(.status.containerStatuses[]?; .restartCount > 0)
-            )
-            | .metadata.name
-    '
-)
-if [ -n "$PODS_RESTARTED" ]; then
-    printf "\n\n"
-    printf "$f_h2_err" "## Pods with restarted containers detected!"
-    echo "$PODS_RESTARTED" | xargs --max-args=1 echo -
-
-    for var in $PODS_RESTARTED; do
-        printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
-        printf "$f_h3_err" "### \$ kubectl logs --previous --all-containers --follow --ignore-errors pod/$var"
-        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var || echo  # a newline on failure for consistency
-    done
 fi
 
 

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -47,8 +47,8 @@ printf "$f_h1_ok" "# Full namespace report"
 #
 printf "\n\n"
 printf "$f_h2_ok" "## Resource overview"
-printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset"
-kubectl get deploy,sts,ds ${ns}
+printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset,cronjob,job"
+kubectl get deploy,sts,ds,cronjob,job ${ns}
 printf "$f_h3_ok" "### \$ kubectl get pod"
 kubectl get pod ${ns} "${psel}"
 printf "$f_h3_ok" "### \$ kubectl get secret,configmap"

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -38,7 +38,8 @@ export f_h3_err="\n\033[${red};1m%s\033[0m\n"
 # We compactify the passing of --namespace, and by using --namespace= we can
 # ensure even a blank string will result in the correct behavior without
 # erroring, which is to use the current contexts namespace.
-export ns=--namespace=${NAMESPACE}
+export ns="--namespace=${NAMESPACE}"
+export psel="--selector=${POD_SELECTOR}"
 
 printf "$f_h1_ok" "# Full namespace report"
 
@@ -46,8 +47,10 @@ printf "$f_h1_ok" "# Full namespace report"
 #
 printf "\n\n"
 printf "$f_h2_ok" "## Resource overview"
-printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset,pod"
-kubectl get deploy,sts,ds,pod ${ns}
+printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset"
+kubectl get deploy,sts,ds ${ns}
+printf "$f_h3_ok" "### \$ kubectl get pod"
+kubectl get pod ${ns} "${psel}"
 printf "$f_h3_ok" "### \$ kubectl get secret,configmap"
 kubectl get secret,cm ${ns}
 printf "$f_h3_ok" "### \$ kubectl get service,ingress,networkpolicy"
@@ -66,7 +69,7 @@ kubectl get sa,role,rolebinding ${ns}
 #       ref: https://github.com/kubernetes/kubernetes/issues/97530
 #
 PODS_RESTARTED=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(
@@ -94,7 +97,7 @@ fi
 # Check if any pods are pending
 #
 PODS_PENDING=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(.status.phase == "Pending")
@@ -116,7 +119,7 @@ fi
 # Check if any pod has a container with a non-ready status
 #
 PODS_NON_READY=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -57,6 +57,8 @@ printf "$f_h3_ok" "### \$ kubectl get service,ingress,networkpolicy"
 kubectl get svc,ing,netpol ${ns}
 printf "$f_h3_ok" "### \$ kubectl get serviceaccount,role,rolebinding"
 kubectl get sa,role,rolebinding ${ns}
+printf "$f_h3_ok" "### \$ kubectl get pv,pvc"
+kubectl get pv,pvc ${ns}
 
 
 # Check if any container of any pod has a restartCount > 0. Then, we inspect


### PR DESCRIPTION
- Show info about restarted pods before pending/non-ready pods
- fix: don't let namespace input not modify kubeconfig's context
- Add pod-selector input
- ci: refactor matrix parameter names
- Add test for pod-selector (require manual output inspection)
- docs: provide more useful example
- ci: ensure actions-tagger has the permissions to update branches/tags
- Show pv and pvc
- Add changelog for 1.1.0
- Add listing of cronjobs and jobs
- [pre-commit.ci] pre-commit autoupdate
- ci: add dependabot config for gha
- ci: update workflows, and use v1,v2,etc tags instead of branches
